### PR TITLE
ver1.0.2

### DIFF
--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Kakeru-O <soarpushcut@gmail.com>"]
 readme = "../README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
streamlit cloudへのデプロイがうまくいかない

poetryの設定がよくなさそう

> Installing the current project: env-bb (0.1.0)
> Error: The current project could not be installed: No file/folder found for package env-bb
> If you do not want to install the current project use --no-root.
> If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
> If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file.
> /mount/src/baseballbattingorder